### PR TITLE
Refactor threading: batch and join worker threads in datareq.py and soapreq.py

### DIFF
--- a/datareq.py
+++ b/datareq.py
@@ -84,11 +84,10 @@ def fake(n): # Test function, can be kept or removed.
 
 def thread_loop(block_size):
     dprint('thread_loop({})'.format(block_size)) # Uses local dprint
-    from threading import Thread, Lock # threading was not imported at top
+    from threading import Thread # threading was not imported at top
     import time # time was not imported at top
     counter = 0
     success = 0
-    lock = Lock()
 
     paikat = []
     for kulutus in sorted(xml_dir("kulutus")):
@@ -96,17 +95,21 @@ def thread_loop(block_size):
 
     dprint(f'Paikkoja: {len(paikat)}') # Uses local dprint
     if len(paikat) != 0:
-        with lock:
-            uusi = iter(paikat)
-            for i in range(1,len(paikat)+1):
-                n = next(uusi)
-                t1 = Thread(target=send_generic, args=(n,'DSO')) # Using imported send_generic
-                # t1 = Thread(target=fake, args=(n,)) # for dry testing
-                t1.start()
-                counter += 1
-                print(f'Thread {counter} started, sending {n}')
-                if counter == block_size:
-                    counter = 0
+        active_threads = []
+        for n in paikat:
+            t1 = Thread(target=send_generic, args=(n,'DSO')) # Using imported send_generic
+            # t1 = Thread(target=fake, args=(n,)) # for dry testing
+            t1.start()
+            active_threads.append(t1)
+            counter += 1
+            print(f'Thread {counter} started, sending {n}')
+            if counter == block_size:
+                for t in active_threads:
+                    t.join()
+                active_threads = []
+                counter = 0
+        for t in active_threads:
+            t.join()
         print('\n')
         success = 1
     else:

--- a/soapreq.py
+++ b/soapreq.py
@@ -95,11 +95,10 @@ def fake(n): # This function seems to be for testing only, can be kept or remove
 
 def thread_loop(block_size):
     dprint('thread_loop({})'.format(block_size)) # Uses local dprint
-    from threading import Thread, Lock # threading was not imported at top
+    from threading import Thread # threading was not imported at top
     import time # time was not imported at top
     counter = 0
     success = 0
-    lock = Lock()
 
     paikat = []
     for apoint in sorted(xml_dir("apoint")):
@@ -107,17 +106,21 @@ def thread_loop(block_size):
 
     dprint(f'Paikkoja: {len(paikat)}') # Uses local dprint
     if len(paikat) != 0:
-        with lock:
-            uusi = iter(paikat)
-            for i in range(1,len(paikat)+1):
-                n = next(uusi)
-                t1 = Thread(target=send_generic, args=(n,'DSO')) # Using imported send_generic
-                # t1 = Thread(target=fake, args=(n,)) # for dry testing
-                t1.start()
-                counter += 1
-                print(f'Thread {counter} started, sending {n}')
-                if counter == block_size:
-                    counter = 0
+        active_threads = []
+        for n in paikat:
+            t1 = Thread(target=send_generic, args=(n,'DSO')) # Using imported send_generic
+            # t1 = Thread(target=fake, args=(n,)) # for dry testing
+            t1.start()
+            active_threads.append(t1)
+            counter += 1
+            print(f'Thread {counter} started, sending {n}')
+            if counter == block_size:
+                for t in active_threads:
+                    t.join()
+                active_threads = []
+                counter = 0
+        for t in active_threads:
+            t.join()
         print('\n')
         success = 1
     else:
@@ -130,21 +133,22 @@ def thread_loop(block_size):
     if len(sopimukset) != 0 and success:
         print('Waiting few moments before next phase...')
         time.sleep(30)
-        with lock:
-            try:
-                uusi = iter(sopimukset)
+        counter = 0
+        active_threads = []
+        for n in sopimukset:
+            t2 = Thread(target=send_generic, args=(n,'DDQ')) # Using imported send_generic
+            #t2 = Thread(target=fake, args=(n,)) # for dry testing
+            t2.start()
+            active_threads.append(t2)
+            counter += 1
+            print(f'Thread {counter} started, sending {n}')
+            if counter == block_size:
+                for t in active_threads:
+                    t.join()
+                active_threads = []
                 counter = 0
-                for i in range(1, len(sopimukset)+1):
-                    n = next(uusi)
-                    t2 = Thread(target=send_generic, args=(n,'DDQ')) # Using imported send_generic
-                    #t2 = Thread(target=fake, args=(n,)) # for dry testing
-                    t2.start()
-                    counter += 1
-                    print(f'Thread {counter} started, sending {n}')
-                    if counter == block_size:
-                        counter = 0
-            except StopIteration:
-                print('\n')
+        for t in active_threads:
+            t.join()
         
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
### Motivation
- Simplify and harden the thread handling to avoid using a shared `Lock` and to ensure worker threads are properly waited on in batches.
- Limit concurrent workers to `block_size` and avoid potential race conditions or orphaned threads caused by the previous iteration/lock pattern.
- Make threading behavior consistent between `datareq.py` and `soapreq.py` and preserve use of the imported `send_generic` worker.

### Description
- Replaced the `Lock`-based iteration with an `active_threads` list in `datareq.py` and `soapreq.py` and removed the `Lock` import and `lock` variable.
- Start threads and append them to `active_threads`, joining all threads when the running count reaches `block_size`, and perform a final join after the loop to wait for any remaining threads.
- Applied the same batching/joining logic to the second-phase `sopimukset` loop in `soapreq.py` so both phases behave consistently with `block_size`.
- Kept the `fake` test helper and local `time`/`random` imports in-place for dry testing comments and clarity.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccfc0c5e08322834f37c141ed874f)